### PR TITLE
feat: files to work with docker and database examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,4 @@ build-iPhoneSimulator/
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key
+/config/database.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,43 @@
+FROM ruby:3.0.2-alpine 
+
+RUN apk add --update --virtual \
+    runtime-deps \
+    postgresql-client \
+    build-base \
+    libxml2-dev \
+    libxslt-dev \
+    mysql-client \
+    mariadb-dev \
+    sqlite-dev \
+    nodejs \
+    yarn \
+    npm \
+    libffi-dev \
+    readline \
+    build-base \
+    postgresql-dev \
+    libc-dev \
+    linux-headers \
+    readline-dev \
+    file \
+    git \
+    tzdata \
+    && rm -rf /var/cache/apk/*
+
+WORKDIR /app
+COPY Gemfile Gemfile.lock /app/
+
+ENV BUNDLE_PATH /gems
+#RUN yarn install
+
+RUN gem install bundler -v 2.3.4
+RUN bundle install
+RUN apk add imagemagick
+RUN apk add ffmpeg
+RUN apk add poppler
+
+COPY . /app/
+
+CMD ["sh"]
+
+EXPOSE 3000

--- a/config/database_example.yml
+++ b/config/database_example.yml
@@ -84,3 +84,4 @@ production:
   database: OT220_Server_production
   username: OT220_Server
   password: <%= ENV['OT220_SERVER_DATABASE_PASSWORD'] %>
+

--- a/config/database_example_docker.yml
+++ b/config/database_example_docker.yml
@@ -1,0 +1,21 @@
+default: &default
+  adapter: postgresql
+  encoding: unicode
+  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  host: postgres_db
+  username: postgres
+  password: postgres
+
+development:
+  <<: *default
+  database: OT220_Server_development
+  
+test:
+  <<: *default
+  database: OT220_Server_test
+
+# production:
+#   <<: *default
+#   database: OT220_Server_production
+#   username: OT220_Server
+#   password: <%= ENV['OT220_SERVER_DATABASE_PASSWORD'] %>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,27 @@
+version: "3.7"
+
+services:
+  ruby_dev:
+    build: .
+    command: sh -c "rm -f tmp/pids/server.pid && bundle exec rails s -p 3000 -b '0.0.0.0'"
+    ports:
+      - "3000:3000"
+    volumes:
+      - ./:/app
+    depends_on:
+      - postgres_db
+
+  postgres_db:
+    image: postgres:alpine
+    restart: unless-stopped
+    volumes:
+      - db-data:/var/lib/postgresql/data
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: postgres
+    ports:
+      - "5432:5432"
+      
+volumes:
+  db-data:


### PR DESCRIPTION
Este cambio contiene los archivos necesarios para trabajar con docker :whale2: 

Dockerfile
docker-compose
Dos archivos database_example.yml de ejemplo: Uno para trabajar normalmente sin docker y el otro con docker.